### PR TITLE
Specifying directories as input to jsdoc causes jsdoc-sphinx to fail

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -28,7 +28,7 @@ function publish(taffyData, options, tutorials) {
 
   // README.rst must be kept as it is.
   var readme = _.find(env.opts._, /README.rst/);
-  if (readme) {
+  if (readme && !fs.lstatSync(readme).isDirectory()) {
     logger.debug('Load README.rst file:', readme);
     options.readme = fs.readFileSync(readme);
   }


### PR DESCRIPTION
To reproduce call jsdoc like:

node_modules.bin\jsdoc --verbose -t node_modules\jsdoc-sphinx\template --recurse $JS_DIR -d $DOC_DIR.
