### PR TITLE
Fix incompatible dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jsdoc -t node_modules/jsdoc-sphinx/template -d OUTPUT_DIR JS_SOURCE_DIR/FILE
 
 ## Reference
 
-- http://usejsdoc.org/
+- https://jsdoc.app/
 
 ## License
 Licensed under The MIT License (MIT)

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   },
   "homepage": "https://github.com/HumanBrainProject/jsdoc-sphinx",
   "peerDependencies": {
-    "jsdoc": "^3.3.3"
+    "jsdoc": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^2",
     "eslint-config-google": "^0.5.0",
-    "jsdoc": "^3.3.3"
+    "jsdoc": "^4.0.0"
   },
   "dependencies": {
     "async": "^1.5.0",
@@ -52,7 +52,6 @@
     "deasync": "^0.1.3",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
-    "mustache": "^2.2.0",
-    "sync": "^0.2.5"
+    "mustache": "^2.2.0"
   }
 }


### PR DESCRIPTION
Simply removes a unused dependency to sync, which in turn brought with it node-fibers which can't be installed on modern systems anymore (and shouldn't, see https://github.com/laverdet/node-fibers).